### PR TITLE
Feat: Use Compose compiler gradle plugin and update Kotlin to 2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.compose.compiler)
 }
 
 android {
@@ -36,10 +37,10 @@ android {
     buildFeatures {
         compose = true
     }
+}
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.13"
-    }
+composeCompiler {
+    enableStrongSkippingMode = true
 }
 
 dependencies {
@@ -58,9 +59,6 @@ dependencies {
     androidTestImplementation(libs.compose.test.ui)
     debugImplementation(libs.compose.test.ui.manifest)
     androidTestImplementation(platform(libs.compose.bom))
-
-
-
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.4.0"
-kotlin = "1.9.23"
+agp = "8.4.1"
+kotlin = "2.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"
@@ -31,8 +31,8 @@ compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling
 compose-test-ui = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 compose-test-ui-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
-
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 


### PR DESCRIPTION
To simplify the set up of Compose, I'm updating the project to use the new Compose Compiler Gradle plugin which lets configure the Compose compiler with a type safe API. The Compose Compiler Gradle plugin’s versioning matches Kotlin’s, and it is available from Kotlin 2.0.0.
