### PR TITLE
Feat: Add MVI Support to ViewModels via Delegate

### DIFF
--- a/app/src/main/java/com/felipecastilhos/gardentracker/MainActivity.kt
+++ b/app/src/main/java/com/felipecastilhos/gardentracker/MainActivity.kt
@@ -1,20 +1,26 @@
 package com.felipecastilhos.gardentracker
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.felipecastilhos.gardentracker.features.mygarden.MyGardenContract.SideEffect.NewPlantHasBeenAdded
+import com.felipecastilhos.gardentracker.features.mygarden.MyGardenContract.UiAction
 import com.felipecastilhos.gardentracker.features.mygarden.MyGardenViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -27,17 +33,37 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         setContent {
-            val message by viewModel.viewState.collectAsState()
+            val sideEffect = viewModel.sideEffect
+            val context = LocalContext.current
 
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Greetings(message ?: "")
-                Spacer(modifier = Modifier.height(15.dp))
-                Button(onClick = { viewModel.updateMessage("Updated")}) {
-                    Text(text = "Update")
+            LaunchedEffect(sideEffect) {
+                sideEffect.collect {
+                    when (it) {
+                        NewPlantHasBeenAdded -> Toast.makeText(
+                            context,
+                            "New Plant added",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                }
+            }
+            val uiState by viewModel.uiState.collectAsState()
+
+            if (uiState.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.fillMaxSize())
+            } else {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    uiState.plants.forEach {
+                        PlantName(it)
+                    }
+                    Spacer(modifier = Modifier.height(15.dp))
+                    Button(onClick = { viewModel.onAction(UiAction.AddNewPlant) }) {
+                        Text(text = "Update")
+                    }
                 }
             }
         }
@@ -45,8 +71,8 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greetings(message: String) = Text(text = message)
+fun PlantName(name: String) = Text(text = name)
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingsPreview() = Greetings("My Garden")
+fun GreetingsPreview() = PlantName("My Garden")

--- a/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/MVI.kt
+++ b/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/MVI.kt
@@ -1,0 +1,16 @@
+package com.felipecastilhos.gardentracker.core.mvi
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+
+interface MVI<UiAction, UiState, SideEffect> {
+    val uiState: StateFlow<UiState>
+    val sideEffect: Flow<SideEffect>
+
+    fun onAction(uiAction: UiAction)
+    fun updateUiState(block: UiState.() -> UiState)
+    fun updateUiState(newUiState: UiState)
+
+    fun CoroutineScope.emitSideEffect(effect: SideEffect)
+}

--- a/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/MVIDelegate.kt
+++ b/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/MVIDelegate.kt
@@ -1,0 +1,31 @@
+package com.felipecastilhos.gardentracker.core.mvi
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+
+class MVIDelegate<UiAction, UiState, SideEffect> internal constructor(
+    initialUiState: UiState,
+) : MVI<UiAction, UiState, SideEffect> {
+    private val _uiState = MutableStateFlow(initialUiState)
+    override val uiState: StateFlow<UiState>
+        get() = _uiState.asStateFlow()
+
+    private val _sideEffect by lazy { Channel<SideEffect>() }
+    override val sideEffect: Flow<SideEffect> by lazy { _sideEffect.receiveAsFlow() }
+
+    override fun CoroutineScope.emitSideEffect(effect: SideEffect) {
+        this.launch {
+            _sideEffect.send(effect)
+        }
+    }
+
+    override fun updateUiState(newUiState: UiState) = _uiState.update { newUiState }
+    override fun updateUiState(block: UiState.() -> UiState) = _uiState.update(block)
+    override fun onAction(uiAction: UiAction) = Unit
+}
+
+fun <UiState, UiAction, SideEffect> mvi(
+    initialUiState: UiState,
+): MVI<UiAction, UiState, SideEffect> = MVIDelegate(initialUiState = initialUiState)

--- a/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/SideEffect.kt
+++ b/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/SideEffect.kt
@@ -1,0 +1,3 @@
+package com.felipecastilhos.gardentracker.core.mvi
+
+interface SideEffect

--- a/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/UiAction.kt
+++ b/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/UiAction.kt
@@ -1,0 +1,3 @@
+package com.felipecastilhos.gardentracker.core.mvi
+
+interface UiAction

--- a/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/UiState.kt
+++ b/app/src/main/java/com/felipecastilhos/gardentracker/core/mvi/UiState.kt
@@ -1,0 +1,3 @@
+package com.felipecastilhos.gardentracker.core.mvi
+
+interface UiState

--- a/app/src/main/java/com/felipecastilhos/gardentracker/features/mygarden/MyGardenContract.kt
+++ b/app/src/main/java/com/felipecastilhos/gardentracker/features/mygarden/MyGardenContract.kt
@@ -1,0 +1,14 @@
+package com.felipecastilhos.gardentracker.features.mygarden
+
+interface MyGardenContract {
+    data class UiState(val isLoading: Boolean = true, val plants: List<String> = listOf())
+
+    sealed interface UiAction {
+        data object LoadPlants : UiAction
+        data object AddNewPlant : UiAction
+    }
+
+    sealed interface SideEffect {
+        data object NewPlantHasBeenAdded : SideEffect
+    }
+}

--- a/app/src/test/java/com/felipecastilhos/gardentracker/features/mygarden/MyGardenViewModelTest.kt
+++ b/app/src/test/java/com/felipecastilhos/gardentracker/features/mygarden/MyGardenViewModelTest.kt
@@ -2,7 +2,11 @@ package com.felipecastilhos.gardentracker.features.mygarden
 
 import app.cash.turbine.test
 import com.felipecastilhos.gardentracker.SuspendingTest
+import com.felipecastilhos.gardentracker.features.mygarden.MyGardenContract.*
 import junit.framework.TestCase.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -17,14 +21,38 @@ internal class MyGardenViewModelTest : SuspendingTest() {
 
     @Test
     fun `start viewmodel with loading state`() = runTest {
-        assertEquals("Loading", viewModel.viewState.value)
+        assertEquals(true, viewModel.uiState.value.isLoading)
     }
 
     @Test
-    fun `fetch a new message`() = runTest {
-        viewModel.viewState.test {
-            assertEquals("Loading", awaitItem())
-            assertEquals("My Garden", awaitItem())
+    fun `Loading plants show a loading first`() = runTest {
+        viewModel.uiState.test {
+            assertEquals(UiState(isLoading = true, listOf()), awaitItem())
+            assertEquals(UiState(isLoading = false, listOf("Plant 1")), awaitItem())
+        }
+    }
+
+    @Test
+    fun `Loading plants return a list containing plants`() = runTest {
+        viewModel.uiState.test {
+            skipItems(1) //skip the loading
+            assertEquals(UiState(isLoading = false, listOf("Plant 1")), awaitItem())
+        }
+    }
+
+    @Test
+    fun `AddNewPlant add a new plant to the plants list`()  = runTest {
+        viewModel.onAction(UiAction.AddNewPlant)
+        viewModel.uiState.test {
+            assertEquals(UiState(isLoading = false, plants = listOf("Plant 1")), awaitItem())
+        }
+    }
+
+    @Test
+    fun `AddNewPlant action send a NewPlantHasBeenAdded side effect`()  = runTest {
+        viewModel.onAction(UiAction.AddNewPlant)
+        viewModel.sideEffect.test {
+            assertEquals(SideEffect.NewPlantHasBeenAdded, awaitItem())
         }
     }
 }


### PR DESCRIPTION
This PR introduces Model-View-Intent (MVI) architecture support to our Android application's ViewModels using a delegate. The implementation aims to enhance the separation of concerns, improve state management, and simplify the handling of UI states and events.

Key Changes:

- Integrated MVI pattern into existing ViewModels.
- Added a delegate to manage state and intents within ViewModels.
- Updated ViewModel classes to utilize the new MVI delegate.
- Refactored existing code to align with MVI architecture principles.

Implementation Details:

1. MVI Delegate:

- Created a reusable delegate that encapsulates the logic for state and intent handling.
- This delegate ensures that the ViewModels adhere to the MVI pattern, promoting unidirectional data flow.

2. MVI Contracts
- UIState: Holds the UiState to be rendered
- UIActions: Is the intents triggered by user and manipulates the UiState
- SideEffects: ViewModel can also fire a one-time event called SideEffects like showing a Toast or navigating to another screen

3. ViewModel Refactoring:

- Refactored ViewModel classes to use the new delegate.
- Create UI Contracts to holds the UIStates, UIActions and SideEffects
- Modified methods to emit states and handle intents according to the MVI architecture.

4. State Management:

- Enhanced state management by introducing immutable state objects.
- Ensured that state changes are handled efficiently and predictably.

5. UI Updates:

- Updated UI components to observe and react to state changes from the ViewModels.
- Improved the handling of UI events, making the UI more responsive and interactive.